### PR TITLE
git deleted files should not trigger false alarm and be treated as valid. 

### DIFF
--- a/.github/scripts/validate_files.py
+++ b/.github/scripts/validate_files.py
@@ -166,8 +166,7 @@ def main():
             stop_docker_container("prism")
             stop_docker_container("fastapi")
         else:
-            print(f"⚠️ File {file_path} does not exist locally.")
-            all_valid = False
+            print(f"⚠️ File {file_path} does not exist, skipping validation.")
 
     if not all_valid:
         exit(1)


### PR DESCRIPTION
This is a small fix. 

== Problem
The deleted files, when pushing to GIT, will invalidate the whole batch. This is a false alarm. 

== Fix
It will only print out a message and treat the removed file as valid. 

