### PR TITLE
Fix/schema identifier inconsistencies: allow identifier strings in cross-reference properties

### DIFF
--- a/check_API.py
+++ b/check_API.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""
+SKG-IF API checker. Two modes:
+
+1. Static (default): validate cross-references in sample data files against
+   the local file system — no running server needed.
+
+2. Live (--live): run HTTP tests against the API stack. Requires the Docker
+   stack to be running (cd testing && docker compose up).
+   --base-url  Prism base URL  (default: http://localhost:4010)
+   --fastapi   FastAPI base URL (default: http://localhost:8000)
+   Use FastAPI directly for cases where Prism cannot route (e.g. full URL path params).
+
+Run from the repo root:
+    python check_API.py               # static only
+    python check_API.py --live        # static + live
+    python check_API.py --live --base-url http://localhost:4010 --fastapi http://localhost:8000
+
+Live test coverage:
+  - List endpoints     all 7 entity types return HTTP 200 with non-empty @graph
+  - Pagination         page_size=1 returns 1 item; page=2 returns correct page meta
+  - Detail (plain id)  products, persons, organisations, grants by short filename id
+  - Detail (full URL)  percent-encoded full local_identifier URL via FastAPI direct
+                       (Prism cannot route path params containing slashes)
+  - embedding=false       cross-references remain as strings (default behaviour)
+  - embedding=true        relevant_organisations[0], topics[].term, contributions[].by,
+                       manifestations[].biblio.in all expand to inline entity objects
+  - UNEXPANDABLE       missing cross-ref target is marked "<id> UNEXPANDABLE"
+  - 404                unknown id returns HTTP 404
+"""
+
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+from urllib.parse import quote
+
+REPO_ROOT = os.path.dirname(os.path.abspath(__file__))
+SAMPLE_DATA = os.path.join(REPO_ROOT, "openapi", "ver", "current", "sample_data")
+
+# Mirrors EXPAND_SPECS in openapi/docker_build/app.py — update both if cross-ref properties change.
+# Each tuple: (path_segments, target_dirs)
+# None in path_segments means "iterate list items at this position"
+EXPAND_SPECS: dict[str, list[tuple[list, list[str]]]] = {
+    "products": [
+        (["topics", None, "term"],                               ["topics"]),
+        (["contributions", None, "by"],                          ["persons", "organisations"]),
+        (["contributions", None, "declared_affiliations", None], ["organisations"]),
+        (["manifestations", None, "biblio", "in"],               ["venues"]),
+        (["manifestations", None, "biblio", "hosting_data_source"], ["datasources"]),
+        (["relevant_organisations", None],                       ["organisations"]),
+        (["funding", None],                                      ["grants"]),
+    ],
+    "persons": [
+        (["affiliations", None, "affiliation"],                  ["organisations"]),
+    ],
+    "grants": [
+        (["beneficiaries", None],                                ["organisations"]),
+        (["contributions", None, "by"],                          ["persons", "organisations"]),
+        (["contributions", None, "declared_affiliations", None], ["organisations"]),
+        (["funding_agency"],                                     ["organisations"]),
+    ],
+}
+
+# Cross-references intentionally left unresolvable (for negative-case testing)
+KNOWN_UNEXPANDABLE = {
+    "org_does_not_exist",
+}
+
+
+# ---------------------------------------------------------------------------
+# Static checks
+# ---------------------------------------------------------------------------
+
+def file_exists(identifier: str, type_dirs: list[str]) -> bool:
+    short = identifier.rstrip("/").split("/")[-1]
+    candidates = [short, short + ".json"]
+    if not identifier.startswith("http"):
+        candidates = [identifier, identifier + ".json"] + candidates
+    for type_dir in type_dirs:
+        for candidate in candidates:
+            if os.path.isfile(os.path.join(SAMPLE_DATA, type_dir, candidate)):
+                return True
+    return False
+
+
+def collect_refs(entity, path: list, target_dirs: list[str]) -> list[tuple[str, list[str]]]:
+    """Walk entity following path, collecting (identifier, target_dirs) for string leaves.
+    Mirrors the traversal logic of _expand_at_path in app.py."""
+    if not path:
+        return []
+    head, *tail = path
+    results = []
+    if head is None:
+        if not isinstance(entity, list):
+            return []
+        for item in entity:
+            if not tail:
+                if isinstance(item, str):
+                    results.append((item, target_dirs))
+            else:
+                results.extend(collect_refs(item, tail, target_dirs))
+    else:
+        if not isinstance(entity, dict):
+            return []
+        val = entity.get(head)
+        if val is None:
+            return []
+        if not tail:
+            if isinstance(val, str):
+                results.append((val, target_dirs))
+        else:
+            results.extend(collect_refs(val, tail, target_dirs))
+    return results
+
+
+def check_file(filepath: str, type_name: str, specs) -> tuple[int, int, int]:
+    """Returns (ok, known_missing, unexpected_missing) counts."""
+    with open(filepath) as f:
+        data = json.load(f)
+    entities = data.get("@graph", [data])
+
+    ok = known_missing = unexpected_missing = 0
+
+    for entity in entities:
+        for path, target_dirs in specs:
+            for ref_id, dirs in collect_refs(entity, path, target_dirs):
+                short = ref_id.rstrip("/").split("/")[-1]
+                if file_exists(ref_id, dirs):
+                    ok += 1
+                    print(f"  [OK]      {'.'.join(str(s) for s in path if s)} -> {short}")
+                elif short in KNOWN_UNEXPANDABLE:
+                    known_missing += 1
+                    print(f"  [SKIP]    {'.'.join(str(s) for s in path if s)} -> {short}  (intentionally missing)")
+                else:
+                    unexpected_missing += 1
+                    print(f"  [MISSING] {'.'.join(str(s) for s in path if s)} -> {ref_id}  (targets: {dirs})")
+    return ok, known_missing, unexpected_missing
+
+
+def run_static_checks() -> bool:
+    total_ok = total_known = total_missing = 0
+
+    for type_name, specs in EXPAND_SPECS.items():
+        type_dir = os.path.join(SAMPLE_DATA, type_name)
+        if not os.path.isdir(type_dir):
+            print(f"\n[WARN] directory not found: {type_name}/")
+            continue
+        files = sorted(f for f in os.listdir(type_dir) if f.endswith(".json"))
+        if not files:
+            print(f"\n[WARN] no JSON files in {type_name}/")
+            continue
+        for fname in files:
+            print(f"\n{type_name}/{fname}")
+            ok, known, missing = check_file(os.path.join(type_dir, fname), type_name, specs)
+            if ok == 0 and known == 0 and missing == 0:
+                print("  (no cross-references)")
+            total_ok += ok
+            total_known += known
+            total_missing += missing
+
+    print(f"\n{'='*50}")
+    print(f"Cross-references resolved : {total_ok}")
+    print(f"Intentionally missing     : {total_known}")
+    print(f"Unexpected missing        : {total_missing}")
+
+    if total_missing:
+        print("\nFAIL — unexpected missing cross-references found")
+        return False
+    print("\nOK")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Live HTTP checks
+# ---------------------------------------------------------------------------
+
+def get(url: str) -> tuple[int, dict | None]:
+    """Returns (status_code, parsed_json_or_None)."""
+    try:
+        with urllib.request.urlopen(url, timeout=5) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        try:
+            return e.code, json.loads(e.read())
+        except Exception:
+            return e.code, None
+    except Exception as e:
+        print(f"  [ERROR] request failed: {e}")
+        return 0, None
+
+
+def assert_test(description: str, url: str, expected_status: int, check_fn=None) -> bool:
+    status, body = get(url)
+    if status != expected_status:
+        print(f"  [FAIL] {description}")
+        print(f"         expected HTTP {expected_status}, got {status}  ({url})")
+        return False
+    if check_fn and not check_fn(body):
+        print(f"  [FAIL] {description}")
+        print(f"         assertion failed on response body  ({url})")
+        return False
+    print(f"  [OK]   {description}")
+    return True
+
+
+def run_live_checks(base: str, fastapi: str) -> bool:
+    print(f"\nLive checks against {base}  (FastAPI direct: {fastapi})")
+    print("=" * 50)
+
+    passed = failed = 0
+
+    def t(desc, url, status, fn=None):
+        nonlocal passed, failed
+        if assert_test(desc, url, status, fn):
+            passed += 1
+        else:
+            failed += 1
+
+    graph   = lambda r: isinstance(r, dict) and "@graph" in r
+    nonempty = lambda r: isinstance(r.get("@graph"), list) and len(r["@graph"]) > 0
+
+    # --- List endpoints: all entity types return a non-empty @graph ---
+    print("\nList endpoints")
+    for entity_type in ["products", "persons", "organisations", "venues", "datasources", "topics", "grants"]:
+        t(f"GET /{entity_type}", f"{base}/{entity_type}", 200, nonempty)
+
+    # --- Pagination ---
+    print("\nPagination")
+    t("page_size=1 returns exactly 1 item",
+      f"{base}/products?page=1&page_size=1", 200,
+      lambda r: r.get("meta", {}).get("items_count") == 1)
+    t("page=2 returns next page meta",
+      f"{base}/products?page=2&page_size=1", 200,
+      lambda r: r.get("meta", {}).get("page") == 2)
+
+    # --- Detail: plain id ---
+    print("\nDetail endpoint — plain id")
+    t("GET /products/product_expand_test",
+      f"{base}/products/product_expand_test", 200,
+      lambda r: r.get("@graph", [{}])[0].get("entity_type") == "product")
+    t("GET /persons/pers_josiah_carberry",
+      f"{base}/persons/pers_josiah_carberry", 200,
+      lambda r: r.get("@graph", [{}])[0].get("entity_type") == "person")
+    t("GET /organisations/org_brown_university",
+      f"{base}/organisations/org_brown_university", 200,
+      lambda r: r.get("@graph", [{}])[0].get("entity_type") == "organisation")
+    t("GET /grants/grant_1",
+      f"{base}/grants/grant_1", 200,
+      lambda r: r.get("@graph", [{}])[0].get("entity_type") == "grant")
+
+    # --- Detail: full URL (percent-encoded) — Prism may reject; use FastAPI directly ---
+    print(f"\nDetail endpoint — full URL (via FastAPI {fastapi})")
+    full_url = "https://w3id.org/skg-if/sandbox/skg-if-api/product_expand_test"
+    encoded  = quote(full_url, safe="")
+    t("GET /products/<full-url-encoded>",
+      f"{fastapi}/products/{encoded}", 200,
+      lambda r: r.get("@graph", [{}])[0].get("entity_type") == "product")
+
+    # --- embedding=false (default): cross-refs remain as strings — list and detail ---
+    print("\nembedding=false (default)")
+    t("list: relevant_organisations are strings without expand",
+      f"{base}/products/product_expand_test", 200,
+      lambda r: isinstance(r["@graph"][0].get("relevant_organisations", [None])[0], str))
+    t("detail: relevant_organisations are strings without expand",
+      f"{base}/products/product_expand_test", 200,
+      lambda r: isinstance(r["@graph"][0].get("relevant_organisations", [None])[0], str))
+
+    # --- embedding=true: cross-refs expanded to objects — list and detail ---
+    print("\nembedding=true")
+    t("detail: relevant_organisations[0] is expanded to object",
+      f"{base}/products/product_expand_test?embedding=true", 200,
+      lambda r: isinstance(r["@graph"][0].get("relevant_organisations", [None])[0], dict))
+    t("list: relevant_organisations[0] is expanded to object",
+      f"{base}/products/product_expand_test?embedding=true", 200,
+      lambda r: isinstance(r["@graph"][0].get("relevant_organisations", [None])[0], dict))
+    t("topics[0].term is expanded to object",
+      f"{base}/products/product_expand_test?embedding=true", 200,
+      lambda r: isinstance(r["@graph"][0].get("topics", [{}])[0].get("term"), dict))
+    t("contributions[0].by is expanded to object",
+      f"{base}/products/product_expand_test?embedding=true", 200,
+      lambda r: isinstance(r["@graph"][0].get("contributions", [{}])[0].get("by"), dict))
+    t("manifestations[0].biblio.in is expanded to object",
+      f"{base}/products/product_expand_test?embedding=true", 200,
+      lambda r: isinstance(r["@graph"][0].get("manifestations", [{}])[0].get("biblio", {}).get("in"), dict))
+
+    # --- UNEXPANDABLE marker ---
+    print("\nUNEXPANDABLE")
+    t("missing cross-ref is marked UNEXPANDABLE",
+      f"{base}/products/product_expand_test?embedding=true", 200,
+      lambda r: any(
+          isinstance(v, str) and "UNEXPANDABLE" in v
+          for v in r["@graph"][0].get("relevant_organisations", [])
+      ))
+
+    # --- 404 ---
+    print("\n404")
+    t("unknown id returns 404", f"{base}/products/does_not_exist", 404)
+
+    print(f"\n{'='*50}")
+    print(f"Passed: {passed}  Failed: {failed}")
+    if failed:
+        print("\nFAIL")
+        return False
+    print("\nOK")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    live = "--live" in sys.argv
+    base_url = next((sys.argv[i+1] for i, a in enumerate(sys.argv) if a == "--base-url"), "http://localhost:4010")
+    fastapi_url = next((sys.argv[i+1] for i, a in enumerate(sys.argv) if a == "--fastapi"), "http://localhost:8000")
+
+    print("=== Static cross-reference checks ===")
+    static_ok = run_static_checks()
+
+    if live:
+        print("\n=== Live API checks ===")
+        live_ok = run_live_checks(base_url, fastapi_url)
+    else:
+        live_ok = True
+        print("\n(skip live checks — pass --live to enable)")
+
+    sys.exit(0 if static_ok and live_ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/openapi/docker_build/app.py
+++ b/openapi/docker_build/app.py
@@ -8,6 +8,7 @@ import json
 import dotenv
 import logging
 import re
+import copy
 import concurrent.futures
 from typing import List, Dict
 from markdown_plain_text.extention import convert_to_plain_text
@@ -26,6 +27,222 @@ processed_datasets_folder = 'processed_jsonfiles_datasets'
 basex_host = "basex-test"
 
 data_root = "/app/data"
+
+
+def parse_filter(filter_str: str) -> list[tuple[str, str]]:
+    """Parse filter string like 'key1:val1,key2:val2' into [(key, val), ...].
+    Handles values containing colons (e.g. identifiers.value:https://ror.org/024d6js02)."""
+    if not filter_str:
+        return []
+    filters = []
+    for part in filter_str.split(","):
+        idx = part.find(":")
+        if idx > 0:
+            filters.append((part[:idx].strip(), part[idx + 1:].strip()))
+    return filters
+
+
+def resolve_dotted_path(obj, path: str):
+    """Resolve a dotted path like 'relevant_organisations.identifiers.scheme' against a
+    nested dict/list structure. Returns a list of all leaf values found."""
+    parts = path.split(".", 1)
+    key = parts[0]
+    rest = parts[1] if len(parts) > 1 else None
+
+    if isinstance(obj, dict):
+        val = obj.get(key)
+        if val is None:
+            return []
+        if rest is None:
+            return [val] if not isinstance(val, list) else val
+        return resolve_dotted_path(val, rest)
+    elif isinstance(obj, list):
+        results = []
+        for item in obj:
+            results.extend(resolve_dotted_path(item, path))
+        return results
+    return []
+
+
+def matches_filter(graph_item: dict, key: str, value: str) -> bool:
+    """Check if a @graph item matches a single filter key:value.
+    Supports nested dotted paths and cf.search.* convenience filters."""
+    # Convenience filters
+    if key == "cf.search.name":
+        val = graph_item.get("name", "")
+        if isinstance(val, list):
+            return any(value.lower() in n.lower() for n in val if isinstance(n, str))
+        return bool(val and value.lower() in str(val).lower())
+    if key == "cf.search.keyword":
+        keywords = graph_item.get("keywords", [])
+        if isinstance(keywords, str):
+            keywords = [keywords]
+        return any(value.lower() in kw.lower() for kw in keywords if isinstance(kw, str))
+    if key == "cf.search.org_name":
+        # Search name and short_name across all organisation-related properties
+        org_props = [
+            "relevant_organisations",
+            "srv_has_hosting_legal_entity",
+            "srv_has_hosting_organisation",
+            "srv_has_research_infrastructure",
+        ]
+        val_lower = value.lower()
+        for prop in org_props:
+            orgs = graph_item.get(prop, [])
+            if isinstance(orgs, dict):
+                orgs = [orgs]
+            for org in orgs:
+                if not isinstance(org, dict):
+                    continue
+                for field in ("name", "short_name"):
+                    v = org.get(field, "")
+                    if isinstance(v, str) and val_lower in v.lower():
+                        return True
+        return False
+
+    # country filter resolves via hosting organisation
+    if key == "country":
+        resolved = resolve_dotted_path(graph_item, "srv_has_hosting_organisation.country")
+        return any(str(v).lower() == value.lower() for v in resolved)
+
+    # Attribute filters — resolve dotted path
+    resolved = resolve_dotted_path(graph_item, key)
+    return any(str(v).lower() == value.lower() for v in resolved)
+
+
+# Supported filter keys per entity type. Keys not in this set return HTTP 422.
+SUPPORTED_FILTERS = {
+    "services": {
+        "entity_type", "identifiers.scheme", "identifiers.value",
+        "name", "website", "country", "srv_invocation_type",
+        "relevant_organisations.name",
+        "relevant_organisations.identifiers.scheme",
+        "relevant_organisations.identifiers.value",
+        "srv_has_hosting_legal_entity.name",
+        "srv_has_hosting_legal_entity.identifiers.scheme",
+        "srv_has_hosting_legal_entity.identifiers.value",
+        "srv_has_hosting_organisation.name",
+        "srv_has_hosting_organisation.identifiers.scheme",
+        "srv_has_hosting_organisation.identifiers.value",
+        "srv_has_research_infrastructure.name",
+        "srv_has_research_infrastructure.identifiers.scheme",
+        "srv_has_research_infrastructure.identifiers.value",
+        "cf.search.name", "cf.search.keyword", "cf.search.org_name",
+    },
+}
+
+
+def validate_filters(filters: list[tuple[str, str]], type_path: str) -> str | None:
+    """Return an error message if any filter key is not supported, else None."""
+    supported = SUPPORTED_FILTERS.get(type_path)
+    if supported is None:
+        # No filter registry for this type — accept all
+        return None
+    for key, _ in filters:
+        if key not in supported:
+            return f"Unsupported filter key: '{key}'. Supported filters for /{type_path}: {sorted(supported)}"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Entity expansion (embedding=true)
+# ---------------------------------------------------------------------------
+# Each entry maps an entity type path to a list of (path_segments, target_dirs)
+# tuples. path_segments navigates the entity dict; None means "iterate over
+# list items at this position". The final segment (or None) is the leaf value
+# to expand from a string identifier to an inline entity object.
+EXPAND_SPECS: dict[str, list[tuple[list, list[str]]]] = {
+    "products": [
+        (["topics", None, "term"],                              ["topics"]),
+        (["contributions", None, "by"],                         ["persons", "organisations"]),
+        (["contributions", None, "declared_affiliations", None],["organisations"]),
+        (["manifestations", None, "biblio", "in"],              ["venues"]),
+        (["manifestations", None, "biblio", "hosting_data_source"], ["datasources"]),
+        (["relevant_organisations", None],                      ["organisations"]),
+        (["funding", None],                                     ["grants"]),
+    ],
+    "persons": [
+        (["affiliations", None, "affiliation"],                 ["organisations"]),
+    ],
+    "grants": [
+        (["beneficiaries", None],                               ["organisations"]),
+        (["contributions", None, "by"],                         ["persons", "organisations"]),
+        (["contributions", None, "declared_affiliations", None],["organisations"]),
+        (["funding_agency"],                                    ["organisations"]),
+    ],
+}
+
+
+def _load_entity_by_id(identifier: str, type_dir: str) -> dict | None:
+    """Try to load an entity from type_dir matching the given identifier string.
+    The identifier may be a full URL or a plain short string; we match by the
+    last path component as a filename."""
+    dir_path = os.path.join(data_root, type_dir)
+    if not os.path.isdir(dir_path):
+        return None
+    short = identifier.rstrip("/").split("/")[-1]
+    candidates = [short, short + ".json"]
+    if not identifier.startswith("http"):
+        candidates = [identifier, identifier + ".json"] + candidates
+    for candidate in candidates:
+        full_path = os.path.join(dir_path, candidate)
+        if os.path.isfile(full_path):
+            with open(full_path) as f:
+                data = json.load(f)
+            if "@graph" in data and data["@graph"]:
+                return data["@graph"][0]
+            return data
+    return None
+
+
+def _try_expand(identifier: str, target_dirs: list[str]) -> dict:
+    """Return the loaded entity dict, or a stub with UNEXPANDABLE marker."""
+    for type_dir in target_dirs:
+        entity = _load_entity_by_id(identifier, type_dir)
+        if entity is not None:
+            return entity
+    return f"{identifier} UNEXPANDABLE"
+
+
+def _expand_at_path(obj, path: list, target_dirs: list[str]) -> None:
+    """In-place expansion: navigate obj using path, expanding string leaves."""
+    if not path:
+        return
+    head, *tail = path
+    if head is None:
+        # current obj should be a list; operate on each item
+        if not isinstance(obj, list):
+            return
+        for i, item in enumerate(obj):
+            if not tail:
+                if isinstance(item, str):
+                    obj[i] = _try_expand(item, target_dirs)
+            else:
+                _expand_at_path(item, tail, target_dirs)
+    else:
+        if not isinstance(obj, dict):
+            return
+        val = obj.get(head)
+        if val is None:
+            return
+        if not tail:
+            if isinstance(val, str):
+                obj[head] = _try_expand(val, target_dirs)
+        else:
+            _expand_at_path(val, tail, target_dirs)
+
+
+def expand_entity(entity: dict, type_path: str) -> dict:
+    """Expand string cross-references in an entity to inline entity objects.
+    Returns a (deep-copied) modified entity; leaves non-string values untouched."""
+    specs = EXPAND_SPECS.get(type_path)
+    if not specs:
+        return entity
+    entity = copy.deepcopy(entity)
+    for path, target_dirs in specs:
+        _expand_at_path(entity, path, target_dirs)
+    return entity
+
 
 # Solr API
 dotenv.load_dotenv()
@@ -835,22 +1052,38 @@ async def read_root():
     return "<h1>Hello, World!</h1><p>Example: <a href='/products/test.json'>/products/test.json</a></p>"
 
 
-# @app.get("/validate/{file_path}")
-@app.get("/{type_path}/{file_path}")
-async def get_file(type_path: str, file_path: str, accept: str | None = Query(None)):
-    logger.warning(f"type_path: {type_path}")
-    logger.warning(f"original file_path: {file_path}")
-    filename = os.path.basename(file_path)
-    logger.warning(f"filename basename: {filename}")
-    file_path = os.path.join(data_root, type_path, filename)
-    logger.warning(f"file_path: {file_path}")
+# short_local_identifier may be a plain string, a slash-containing string (e.g. 11234/1-1451),
+# or a full URL (e.g. https://w3id.org/skg-if/sandbox/myprov/entity-1 or a DOI URL).
+# Full URLs are percent-encoded by the caller (%2F for slashes); Starlette decodes them back.
+# In all cases we resolve to a file using only the last path segment (see id_for_lookup below).
+@app.get("/{type_path}/{short_local_identifier:path}")
+async def get_file(
+    type_path: str,
+    short_local_identifier: str,
+    accept: str | None = Query(None),
+    embedding: bool = Query(False),
+):
+    logger.warning(f"type_path: {type_path}, short_local_identifier: {short_local_identifier}")
     accept_header = get_accept_header(accept)
-    if os.path.isfile(file_path):
-        with open(file_path, "r") as file:
-            data = json.load(file)
-        return create_response(data, accept_header)
-    else:
-        return JSONResponse(content={"error": f"File not found {file_path}"}, status_code=404)
+
+    # If a full URL was passed, use only the last path segment for file lookup
+    id_for_lookup = short_local_identifier.rstrip("/").split("/")[-1] if short_local_identifier.startswith("http") else short_local_identifier
+    filename_base = id_for_lookup.replace("/", "_")
+    candidates = [id_for_lookup, filename_base]
+    for base in [id_for_lookup, filename_base]:
+        if not base.endswith(".json"):
+            candidates.append(base + ".json")
+
+    for candidate in candidates:
+        full_path = os.path.join(data_root, type_path, candidate)
+        if os.path.isfile(full_path):
+            with open(full_path, "r") as file:
+                data = json.load(file)
+            if embedding and "@graph" in data:
+                data = {**data, "@graph": [expand_entity(item, type_path) for item in data["@graph"]]}
+            return create_response(data, accept_header)
+
+    return JSONResponse(content={"error": f"No record found for: {short_local_identifier}"}, status_code=404)
 
 
 # @app.get("/products/{product_id}")
@@ -885,15 +1118,100 @@ async def get_file(type_path: str, file_path: str, accept: str | None = Query(No
 
 
 @app.get("/{type_path}")
-async def get_items_per_type(type_path: str, accept: str | None = Query(None)):
+async def get_items_per_type(
+    type_path: str,
+    accept: str | None = Query(None),
+    filter: str | None = Query(None, alias="filter"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(10, ge=1),
+    embedding: bool = Query(False),
+):
     """
-    Get all items of a specific type (datasets or tools).
+    Get all items of a specific type.
+    Returns spec-compliant JSON-LD with @context, meta, and @graph.
+    Supports filter, page, page_size, and embedding query parameter.
     """
     accept_header = get_accept_header(accept)
 
     items = load_files(os.path.join(data_root, type_path))
 
-    return create_response({"accept": accept_header, "total": len(items), "items": items}, accept_header)
+    # Extract @graph content from each file and collect @context from the first
+    all_graph = []
+    context = None
+    for file_id, file_data in items.items():
+        if context is None and "@context" in file_data:
+            context = file_data["@context"]
+        if "@graph" in file_data:
+            all_graph.extend(file_data["@graph"])
+        else:
+            all_graph.append(file_data)
+
+    logger.warning(f"get_items_per_type: loaded {len(items)} files, total @graph items: {len(all_graph)}")
+
+    # Apply filters (AND logic)
+    filters = parse_filter(filter)
+    if filters:
+        error = validate_filters(filters, type_path)
+        if error:
+            return JSONResponse(content={"error": error}, status_code=422)
+    if filters:
+        filtered = []
+        for item in all_graph:
+            if all(matches_filter(item, k, v) for k, v in filters):
+                filtered.append(item)
+        logger.warning(f"filter={filter} matched {len(filtered)}/{len(all_graph)} items")
+        all_graph = filtered
+
+    if context is None:
+        context = [
+            "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
+            "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
+            {"@base": "https://w3id.org/skg-if/sandbox/"},
+            "https://w3id.org/skg-if/extension/srv/context/skg-if.json"
+        ]
+
+    # Pagination
+    total_items = len(all_graph)
+    start = (page - 1) * page_size
+    end = start + page_size
+    page_graph = all_graph[start:end]
+
+    # Expand cross-reference string identifiers to inline entity objects
+    if embedding:
+        page_graph = [expand_entity(item, type_path) for item in page_graph]
+    total_pages = (total_items + page_size - 1) // page_size if total_items > 0 else 1
+
+    base_url = f"http://localhost:4010/{type_path}"
+    meta = {
+        "local_identifier": f"{base_url}?page={page}&page_size={page_size}",
+        "entity_type": "search_result_page",
+        "page": page,
+        "page_size": page_size,
+        "items_count": len(page_graph),
+        "part_of": {
+            "local_identifier": base_url,
+            "entity_type": "search_result",
+            "total_items": total_items
+        }
+    }
+    if page < total_pages:
+        meta["next_page"] = {
+            "local_identifier": f"{base_url}?page={page + 1}&page_size={page_size}",
+            "entity_type": "search_result_page"
+        }
+    if page > 1:
+        meta["prev_page"] = {
+            "local_identifier": f"{base_url}?page={page - 1}&page_size={page_size}",
+            "entity_type": "search_result_page"
+        }
+
+    result = {
+        "@context": context,
+        "meta": meta,
+        "@graph": page_graph
+    }
+
+    return create_response(result, accept_header)
 
 
 @app.get("/fetchall", response_class=HTMLResponse)

--- a/openapi/ver/current/sample_data/datasources/datasource_oxford_research_archive.json
+++ b/openapi/ver/current/sample_data/datasources/datasource_oxford_research_archive.json
@@ -1,0 +1,25 @@
+{
+    "@context": [
+        "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
+        "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
+        {"@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"}
+    ],
+    "@graph": [
+        {
+            "local_identifier": "http://example.com/skg-if/api/datasources/datasource_oxford_research_archive",
+            "entity_type": "datasource",
+            "identifiers": [
+                {
+                    "scheme": "doi",
+                    "value": "10.25504/FAIRsharing.rkwr6y"
+                }
+            ],
+            "name": "Oxford University Research Archive",
+            "data_source_classification": "repository",
+            "research_product_types": [
+                "research data",
+                "literature"
+            ]
+        }
+    ]
+}

--- a/openapi/ver/current/sample_data/datasources/datasource_oxford_research_archive.json
+++ b/openapi/ver/current/sample_data/datasources/datasource_oxford_research_archive.json
@@ -2,11 +2,11 @@
     "@context": [
         "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
         "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
-        {"@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"}
+        {"@base": "https://w3id.org/skg-if/sandbox/skg-if-api/"}
     ],
     "@graph": [
         {
-            "local_identifier": "http://example.com/skg-if/api/datasources/datasource_oxford_research_archive",
+            "local_identifier": "https://w3id.org/skg-if/sandbox/skg-if-api/datasource_oxford_research_archive",
             "entity_type": "datasource",
             "identifiers": [
                 {

--- a/openapi/ver/current/sample_data/grants/grant_1.json
+++ b/openapi/ver/current/sample_data/grants/grant_1.json
@@ -3,12 +3,12 @@
         "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
         "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
         {
-            "@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"
+            "@base": "https://w3id.org/skg-if/sandbox/skg-if-api/"
         }
     ],
     "@graph": [
         {
-            "local_identifier": "http://example.com/skg-if/api/grants/grant_1",
+            "local_identifier": "https://w3id.org/skg-if/sandbox/skg-if-api/grant_1",
             "identifiers": [
                 {
                     "scheme": "doi",
@@ -25,7 +25,7 @@
             },
             "acronym": "GraspOS",
             "funding_agency": {
-                "local_identifier": "http://example.com/skg-if/api/organisations/org-xxx",
+                "local_identifier": "https://w3id.org/skg-if/sandbox/skg-if-api/org-xxx",
                 "entity_type": "organisation",
                 "identifiers": [
                     {
@@ -48,7 +48,7 @@
             "website": "https://graspos.eu",
             "beneficiaries": [
                 {
-                    "local_identifier": "http://example.com/skg-if/api/organisations/xxx",
+                    "local_identifier": "https://w3id.org/skg-if/sandbox/skg-if-api/xxx",
                     "entity_type": "organisation",
                     "identifiers": [
                         {
@@ -65,7 +65,7 @@
             "contributions": [
                 {
                     "by": {
-                        "local_identifier": "http://example.com/skg-if/api/persons/xxx",
+                        "local_identifier": "https://w3id.org/skg-if/sandbox/skg-if-api/xxx",
                         "entity_type": "person",
                         "identifiers": [
                             {
@@ -79,7 +79,7 @@
                     },
                     "declared_affiliations": [
                         {
-                            "local_identifier": "http://example.com/skg-if/api/organisations/xxx",
+                            "local_identifier": "https://w3id.org/skg-if/sandbox/skg-if-api/xxx",
                             "entity_type": "organisation",
                             "identifiers": [
                                 {

--- a/openapi/ver/current/sample_data/grants/grant_1.json
+++ b/openapi/ver/current/sample_data/grants/grant_1.json
@@ -8,7 +8,7 @@
     ],
     "@graph": [
         {
-            "local_identifier": "http://example.com/skg-if/api/grants/6f368a3a-b1cf-498f-b2de-27135d1e0011",
+            "local_identifier": "http://example.com/skg-if/api/grants/grant_1",
             "identifiers": [
                 {
                     "scheme": "doi",

--- a/openapi/ver/current/sample_data/organisations/org_brown_university.json
+++ b/openapi/ver/current/sample_data/organisations/org_brown_university.json
@@ -3,12 +3,12 @@
         "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
         "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
         {
-            "@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"
+            "@base": "https://w3id.org/skg-if/sandbox/skg-if-api/"
         }
     ],
     "@graph": [
         {
-            "local_identifier": "http://example.com/skg-if/api/organisations/org_brown_university",
+            "local_identifier": "https://w3id.org/skg-if/sandbox/skg-if-api/org_brown_university",
             "entity_type": "organisation",
             "identifiers": [
                 {

--- a/openapi/ver/current/sample_data/organisations/org_european_commission.json
+++ b/openapi/ver/current/sample_data/organisations/org_european_commission.json
@@ -1,0 +1,24 @@
+{
+    "@context": [
+        "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
+        "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
+        {"@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"}
+    ],
+    "@graph": [
+        {
+            "local_identifier": "http://example.com/skg-if/api/organisations/org_european_commission",
+            "entity_type": "organisation",
+            "identifiers": [
+                {
+                    "scheme": "ror",
+                    "value": "https://ror.org/00k4n6c32"
+                }
+            ],
+            "name": "European Commission",
+            "short_name": "EU",
+            "types": [
+                "funder"
+            ]
+        }
+    ]
+}

--- a/openapi/ver/current/sample_data/organisations/org_european_commission.json
+++ b/openapi/ver/current/sample_data/organisations/org_european_commission.json
@@ -2,11 +2,11 @@
     "@context": [
         "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
         "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
-        {"@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"}
+        {"@base": "https://w3id.org/skg-if/sandbox/skg-if-api/"}
     ],
     "@graph": [
         {
-            "local_identifier": "http://example.com/skg-if/api/organisations/org_european_commission",
+            "local_identifier": "https://w3id.org/skg-if/sandbox/skg-if-api/org_european_commission",
             "entity_type": "organisation",
             "identifiers": [
                 {

--- a/openapi/ver/current/sample_data/organisations/org_john_carter_brown_library.json
+++ b/openapi/ver/current/sample_data/organisations/org_john_carter_brown_library.json
@@ -2,28 +2,27 @@
     "@context": [
         "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
         "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
-        {
-            "@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"
-        }
+        {"@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"}
     ],
     "@graph": [
         {
-            "local_identifier": "http://example.com/skg-if/api/organisations/org_brown_university",
+            "local_identifier": "http://example.com/skg-if/api/organisations/org_john_carter_brown_library",
             "entity_type": "organisation",
             "identifiers": [
                 {
                     "scheme": "ror",
                     "value": "https://ror.org/05gq02987"
+                },
+                {
+                    "scheme": "ror",
+                    "value": "https://ror.org/0274ane14"
                 }
             ],
-            "name": "Brown University",
-            "other_names": [
-                "Brownie"
-            ],
+            "name": "John Carter Brown Library, Brown University, Providence RI, US",
             "short_name": "BU",
             "country": "US",
             "types": [
-                "education"
+                "archive"
             ]
         }
     ]

--- a/openapi/ver/current/sample_data/organisations/org_john_carter_brown_library.json
+++ b/openapi/ver/current/sample_data/organisations/org_john_carter_brown_library.json
@@ -2,11 +2,11 @@
     "@context": [
         "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
         "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
-        {"@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"}
+        {"@base": "https://w3id.org/skg-if/sandbox/skg-if-api/"}
     ],
     "@graph": [
         {
-            "local_identifier": "http://example.com/skg-if/api/organisations/org_john_carter_brown_library",
+            "local_identifier": "https://w3id.org/skg-if/sandbox/skg-if-api/org_john_carter_brown_library",
             "entity_type": "organisation",
             "identifiers": [
                 {

--- a/openapi/ver/current/sample_data/organisations/org_lab_of_science.json
+++ b/openapi/ver/current/sample_data/organisations/org_lab_of_science.json
@@ -2,11 +2,11 @@
     "@context": [
         "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
         "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
-        {"@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"}
+        {"@base": "https://w3id.org/skg-if/sandbox/skg-if-api/"}
     ],
     "@graph": [
         {
-            "local_identifier": "http://example.com/skg-if/api/organisations/org_lab_of_science",
+            "local_identifier": "https://w3id.org/skg-if/sandbox/skg-if-api/org_lab_of_science",
             "entity_type": "organisation",
             "name": "Lab of science, unknown University, Antarctica"
         }

--- a/openapi/ver/current/sample_data/organisations/org_lab_of_science.json
+++ b/openapi/ver/current/sample_data/organisations/org_lab_of_science.json
@@ -1,0 +1,14 @@
+{
+    "@context": [
+        "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
+        "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
+        {"@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"}
+    ],
+    "@graph": [
+        {
+            "local_identifier": "http://example.com/skg-if/api/organisations/org_lab_of_science",
+            "entity_type": "organisation",
+            "name": "Lab of science, unknown University, Antarctica"
+        }
+    ]
+}

--- a/openapi/ver/current/sample_data/persons/pers_john_doe.json
+++ b/openapi/ver/current/sample_data/persons/pers_john_doe.json
@@ -1,0 +1,14 @@
+{
+    "@context": [
+        "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
+        "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
+        {"@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"}
+    ],
+    "@graph": [
+        {
+            "local_identifier": "http://example.com/skg-if/api/persons/pers_john_doe",
+            "entity_type": "person",
+            "name": "John Doe"
+        }
+    ]
+}

--- a/openapi/ver/current/sample_data/persons/pers_john_doe.json
+++ b/openapi/ver/current/sample_data/persons/pers_john_doe.json
@@ -2,11 +2,11 @@
     "@context": [
         "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
         "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
-        {"@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"}
+        {"@base": "https://w3id.org/skg-if/sandbox/skg-if-api/"}
     ],
     "@graph": [
         {
-            "local_identifier": "http://example.com/skg-if/api/persons/pers_john_doe",
+            "local_identifier": "https://w3id.org/skg-if/sandbox/skg-if-api/pers_john_doe",
             "entity_type": "person",
             "name": "John Doe"
         }

--- a/openapi/ver/current/sample_data/persons/pers_josiah_carberry.json
+++ b/openapi/ver/current/sample_data/persons/pers_josiah_carberry.json
@@ -1,0 +1,22 @@
+{
+    "@context": [
+        "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
+        "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
+        {"@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"}
+    ],
+    "@graph": [
+        {
+            "local_identifier": "http://example.com/skg-if/api/persons/pers_josiah_carberry",
+            "entity_type": "person",
+            "identifiers": [
+                {
+                    "scheme": "orcid",
+                    "value": "0000-0002-1825-0097"
+                }
+            ],
+            "given_name": "Josiah",
+            "family_name": "Carberry",
+            "name": "Josiah Carberry"
+        }
+    ]
+}

--- a/openapi/ver/current/sample_data/persons/pers_josiah_carberry.json
+++ b/openapi/ver/current/sample_data/persons/pers_josiah_carberry.json
@@ -2,11 +2,11 @@
     "@context": [
         "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
         "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
-        {"@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"}
+        {"@base": "https://w3id.org/skg-if/sandbox/skg-if-api/"}
     ],
     "@graph": [
         {
-            "local_identifier": "http://example.com/skg-if/api/persons/pers_josiah_carberry",
+            "local_identifier": "https://w3id.org/skg-if/sandbox/skg-if-api/pers_josiah_carberry",
             "entity_type": "person",
             "identifiers": [
                 {

--- a/openapi/ver/current/sample_data/products/dataset_openaire_graph.json
+++ b/openapi/ver/current/sample_data/products/dataset_openaire_graph.json
@@ -1,0 +1,30 @@
+{
+    "@context": [
+        "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
+        "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
+        {"@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"}
+    ],
+    "@graph": [
+        {
+            "local_identifier": "http://example.com/skg-if/api/products/dataset_openaire_graph",
+            "entity_type": "product",
+            "product_type": "research data",
+            "titles": {
+                "en": ["OpenAIRE Graph dataset - new collected projects"]
+            },
+            "abstracts": {
+                "en": ["The dataset includes metadata about projects grants collected by OpenAIRE since October 2024."]
+            },
+            "identifiers": [
+                {
+                    "scheme": "doi",
+                    "value": "10.5281/zenodo.14622592"
+                },
+                {
+                    "scheme": "openalex",
+                    "value": "W4393781519"
+                }
+            ]
+        }
+    ]
+}

--- a/openapi/ver/current/sample_data/products/dataset_openaire_graph.json
+++ b/openapi/ver/current/sample_data/products/dataset_openaire_graph.json
@@ -2,11 +2,11 @@
     "@context": [
         "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
         "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
-        {"@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"}
+        {"@base": "https://w3id.org/skg-if/sandbox/skg-if-api/"}
     ],
     "@graph": [
         {
-            "local_identifier": "http://example.com/skg-if/api/products/dataset_openaire_graph",
+            "local_identifier": "https://w3id.org/skg-if/sandbox/skg-if-api/dataset_openaire_graph",
             "entity_type": "product",
             "product_type": "research data",
             "titles": {

--- a/openapi/ver/current/sample_data/products/journal_article_full.json
+++ b/openapi/ver/current/sample_data/products/journal_article_full.json
@@ -8,7 +8,7 @@
     ],
     "@graph": [
         {
-            "local_identifier": "http://example.com/skg-if/api/products/614a6575-5d6c-416c-a8e1-ddd456d132",
+            "local_identifier": "http://example.com/skg-if/api/products/journal_article_full",
             "entity_type": "product",
             "product_type": "literature",
             "titles": {

--- a/openapi/ver/current/sample_data/products/journal_article_full.json
+++ b/openapi/ver/current/sample_data/products/journal_article_full.json
@@ -3,12 +3,12 @@
         "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
         "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
         {
-            "@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"
+            "@base": "https://w3id.org/skg-if/sandbox/skg-if-api/"
         }
     ],
     "@graph": [
         {
-            "local_identifier": "http://example.com/skg-if/api/products/journal_article_full",
+            "local_identifier": "https://w3id.org/skg-if/sandbox/skg-if-api/journal_article_full",
             "entity_type": "product",
             "product_type": "literature",
             "titles": {
@@ -48,13 +48,13 @@
                                 "scheme": "orcid"
                             }
                         ],
-                        "local_identifier": "http://example.com/skg-if/api/persons/614a6575-5d6c-416c-a8e1-f49a5d589bf8",
+                        "local_identifier": "https://w3id.org/skg-if/sandbox/skg-if-api/614a6575-5d6c-416c-a8e1-f49a5d589bf8",
                         "entity_type": "person"
                     },
                     "declared_affiliations": [
                         {
                             "name": "Center for Plant Biotechnology and Genomics, Universidad Politécnica de Madrid, Madrid, 28223, Spain",
-                            "local_identifier": "http://example.com/skg-if/api/organisations/32bc66c6-38be-4d5f-85db-d44c9f86921f",
+                            "local_identifier": "https://w3id.org/skg-if/sandbox/skg-if-api/32bc66c6-38be-4d5f-85db-d44c9f86921f",
                             "entity_type": "organisation",
                             "country": "ES"
                         }
@@ -72,7 +72,7 @@
                     },
                     "biblio": {
                         "hosting_data_source": {
-                            "local_identifier": "http://example.com/skg-if/api/datasources/6f368a3a-b1cf-498f-b2de-27135d1e0075",
+                            "local_identifier": "https://w3id.org/skg-if/sandbox/skg-if-api/6f368a3a-b1cf-498f-b2de-27135d1e0075",
                             "entity_type": "datasource",
                             "name": "An Archive"
                         },
@@ -85,7 +85,7 @@
                                     "scheme": "issn"
                                 }
                             ],
-                            "local_identifier": "http://example.com/skg-if/api/venues/51f46bc1-00f8-42dd-8221-ac4deb52fb25",
+                            "local_identifier": "https://w3id.org/skg-if/sandbox/skg-if-api/51f46bc1-00f8-42dd-8221-ac4deb52fb25",
                             "entity_type": "venue"
                         }
                     },
@@ -105,7 +105,7 @@
             ],
             "funding": [
                 {
-                    "local_identifier": "http://example.com/skg-if/api/grants/614a6575-5d6c-416c-a8e1-f49a5d58999",
+                    "local_identifier": "https://w3id.org/skg-if/sandbox/skg-if-api/614a6575-5d6c-416c-a8e1-f49a5d58999",
                     "entity_type": "grant",
                     "titles": {
                         "en": "The EU grant ZZ",

--- a/openapi/ver/current/sample_data/products/product_expand_test.json
+++ b/openapi/ver/current/sample_data/products/product_expand_test.json
@@ -2,46 +2,46 @@
     "@context": [
         "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
         "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
-        {"@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"}
+        {"@base": "https://w3id.org/skg-if/sandbox/skg-if-api/"}
     ],
     "@graph": [
         {
-            "local_identifier": "http://example.com/skg-if/api/products/product_expand_test",
+            "local_identifier": "https://w3id.org/skg-if/sandbox/skg-if-api/product_expand_test",
             "entity_type": "product",
             "product_type": "literature",
             "titles": {
                 "en": ["Expand flag test product — cross-references as plain identifier strings"]
             },
             "abstracts": {
-                "en": ["This record is designed to test the expand=true flag. All cross-reference properties hold plain local_identifier strings. Most point to entities that exist as sample data files; one (the second relevant_organisation) points to a non-existent entity and will be marked UNEXPANDABLE."]
+                "en": ["This record is designed to test the embedding=true flag. All cross-reference properties hold plain local_identifier strings. Most point to entities that exist as sample data files; one (the second relevant_organisation) points to a non-existent entity and will be marked UNEXPANDABLE."]
             },
             "topics": [
                 {
-                    "term": "http://example.com/skg-if/api/topics/topic_computer_science"
+                    "term": "https://w3id.org/skg-if/sandbox/skg-if-api/topic_computer_science"
                 }
             ],
             "relevant_organisations": [
-                "http://example.com/skg-if/api/organisations/org_european_commission",
-                "http://example.com/skg-if/api/organisations/org_does_not_exist"
+                "https://w3id.org/skg-if/sandbox/skg-if-api/org_european_commission",
+                "https://w3id.org/skg-if/sandbox/skg-if-api/org_does_not_exist"
             ],
             "funding": [
-                "http://example.com/skg-if/api/grants/grant_1"
+                "https://w3id.org/skg-if/sandbox/skg-if-api/grant_1"
             ],
             "contributions": [
                 {
                     "role": "author",
                     "rank": 1,
-                    "by": "http://example.com/skg-if/api/persons/pers_josiah_carberry",
+                    "by": "https://w3id.org/skg-if/sandbox/skg-if-api/pers_josiah_carberry",
                     "declared_affiliations": [
-                        "http://example.com/skg-if/api/organisations/org_brown_university"
+                        "https://w3id.org/skg-if/sandbox/skg-if-api/org_brown_university"
                     ]
                 }
             ],
             "manifestations": [
                 {
                     "biblio": {
-                        "in": "http://example.com/skg-if/api/venues/venue_journal_of_psychoceramics",
-                        "hosting_data_source": "http://example.com/skg-if/api/datasources/datasource_oxford_research_archive"
+                        "in": "https://w3id.org/skg-if/sandbox/skg-if-api/venue_journal_of_psychoceramics",
+                        "hosting_data_source": "https://w3id.org/skg-if/sandbox/skg-if-api/datasource_oxford_research_archive"
                     },
                     "dates": {
                         "publication": ["2025-01-01"]

--- a/openapi/ver/current/sample_data/products/product_expand_test.json
+++ b/openapi/ver/current/sample_data/products/product_expand_test.json
@@ -1,0 +1,53 @@
+{
+    "@context": [
+        "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
+        "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
+        {"@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"}
+    ],
+    "@graph": [
+        {
+            "local_identifier": "http://example.com/skg-if/api/products/product_expand_test",
+            "entity_type": "product",
+            "product_type": "literature",
+            "titles": {
+                "en": ["Expand flag test product — cross-references as plain identifier strings"]
+            },
+            "abstracts": {
+                "en": ["This record is designed to test the expand=true flag. All cross-reference properties hold plain local_identifier strings. Most point to entities that exist as sample data files; one (the second relevant_organisation) points to a non-existent entity and will be marked UNEXPANDABLE."]
+            },
+            "topics": [
+                {
+                    "term": "http://example.com/skg-if/api/topics/topic_computer_science"
+                }
+            ],
+            "relevant_organisations": [
+                "http://example.com/skg-if/api/organisations/org_european_commission",
+                "http://example.com/skg-if/api/organisations/org_does_not_exist"
+            ],
+            "funding": [
+                "http://example.com/skg-if/api/grants/grant_1"
+            ],
+            "contributions": [
+                {
+                    "role": "author",
+                    "rank": 1,
+                    "by": "http://example.com/skg-if/api/persons/pers_josiah_carberry",
+                    "declared_affiliations": [
+                        "http://example.com/skg-if/api/organisations/org_brown_university"
+                    ]
+                }
+            ],
+            "manifestations": [
+                {
+                    "biblio": {
+                        "in": "http://example.com/skg-if/api/venues/venue_journal_of_psychoceramics",
+                        "hosting_data_source": "http://example.com/skg-if/api/datasources/datasource_oxford_research_archive"
+                    },
+                    "dates": {
+                        "publication": ["2025-01-01"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/openapi/ver/current/sample_data/topics/topic_computer_science.json
+++ b/openapi/ver/current/sample_data/topics/topic_computer_science.json
@@ -1,0 +1,23 @@
+{
+    "@context": [
+        "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
+        "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
+        {"@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"}
+    ],
+    "@graph": [
+        {
+            "local_identifier": "http://example.com/skg-if/api/topics/topic_computer_science",
+            "entity_type": "topic",
+            "identifiers": [
+                {
+                    "scheme": "wikidata",
+                    "value": "https://www.wikidata.org/wiki/Q21198"
+                }
+            ],
+            "labels": {
+                "en": "Computer Science",
+                "it": "Informatica"
+            }
+        }
+    ]
+}

--- a/openapi/ver/current/sample_data/topics/topic_computer_science.json
+++ b/openapi/ver/current/sample_data/topics/topic_computer_science.json
@@ -2,11 +2,11 @@
     "@context": [
         "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
         "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
-        {"@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"}
+        {"@base": "https://w3id.org/skg-if/sandbox/skg-if-api/"}
     ],
     "@graph": [
         {
-            "local_identifier": "http://example.com/skg-if/api/topics/topic_computer_science",
+            "local_identifier": "https://w3id.org/skg-if/sandbox/skg-if-api/topic_computer_science",
             "entity_type": "topic",
             "identifiers": [
                 {

--- a/openapi/ver/current/sample_data/venues/venue_journal_of_psychoceramics.json
+++ b/openapi/ver/current/sample_data/venues/venue_journal_of_psychoceramics.json
@@ -2,11 +2,11 @@
     "@context": [
         "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
         "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
-        {"@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"}
+        {"@base": "https://w3id.org/skg-if/sandbox/skg-if-api/"}
     ],
     "@graph": [
         {
-            "local_identifier": "http://example.com/skg-if/api/venues/venue_journal_of_psychoceramics",
+            "local_identifier": "https://w3id.org/skg-if/sandbox/skg-if-api/venue_journal_of_psychoceramics",
             "entity_type": "venue",
             "identifiers": [
                 {

--- a/openapi/ver/current/sample_data/venues/venue_journal_of_psychoceramics.json
+++ b/openapi/ver/current/sample_data/venues/venue_journal_of_psychoceramics.json
@@ -1,0 +1,22 @@
+{
+    "@context": [
+        "https://w3id.org/skg-if/context/1.1.0/skg-if.json",
+        "https://w3id.org/skg-if/context/1.0.0/skg-if-api.json",
+        {"@base": "https://w3id.org/skg-if/sandbox/my-skg-acronym/"}
+    ],
+    "@graph": [
+        {
+            "local_identifier": "http://example.com/skg-if/api/venues/venue_journal_of_psychoceramics",
+            "entity_type": "venue",
+            "identifiers": [
+                {
+                    "scheme": "issn",
+                    "value": "0264-3561"
+                }
+            ],
+            "name": "Journal of Psychoceramics",
+            "acronym": "JPC",
+            "type": "journal"
+        }
+    ]
+}

--- a/openapi/ver/current/skg-if-openapi.yaml
+++ b/openapi/ver/current/skg-if-openapi.yaml
@@ -1480,7 +1480,11 @@ components:
                 required: [ "term" ]
                 properties:
                   term:
-                    $ref: '#/components/schemas/Topic'
+                    description: Identifier of a `topic`. May be a plain identifier string or a full Topic object.
+                    anyOf:
+                      - type: string
+                        description: Topic identifier (local_identifier or external URI)
+                      - $ref: '#/components/schemas/Topic'
                   # TODO provenance ?
             contributions:
               type: array
@@ -1494,14 +1498,27 @@ components:
                 $ref: '#/components/schemas/ProductManifestation'
             relevant_organisations:
               type: array
-              description: List of relevant Organisation  associated with the `product`, in case the individual affiliations of a `person` are not available.
+              description: >
+                List of relevant Organisation identifiers associated with the `product`, in case
+                the individual affiliations of a `person` are not available. Each item may be a
+                plain identifier string (local_identifier or external URI) or a full Organisation
+                object. API responses may expand identifiers to full Organisation objects.
               items:
-                $ref: '#/components/schemas/Organisation'
+                anyOf:
+                  - type: string
+                    description: Organisation identifier (local_identifier or external URI)
+                  - $ref: '#/components/schemas/Organisation'
             funding:
               type: array
-              description:  List of `grant` associated with the `product`
+              description: >
+                List of Grant identifiers associated with the `product`. Each item may be a
+                plain identifier string (local_identifier or external URI) or a full Grant
+                object. API responses may expand identifiers to full Grant objects.
               items:
-                $ref: '#/components/schemas/GrantLite'
+                anyOf:
+                  - type: string
+                    description: Grant identifier (local_identifier or external URI)
+                  - $ref: '#/components/schemas/GrantLite'
             related_products:
               $ref: '#/components/schemas/ProductRelated'
 
@@ -1581,8 +1598,12 @@ components:
       required: [ "by" ]
       properties:
         by:
-          description: The identifier of a `person` or `organisation` contributing to a `product`.
-          oneOf:
+          description: >
+            Identifier of a `person` or `organisation` contributing to a `product`. May be
+            a plain identifier string or a typed object (discriminated by entity_type).
+          anyOf:
+            - type: string
+              description: Agent identifier (local_identifier or external URI)
             - $ref: '#/components/schemas/PersonLite'
             - $ref: '#/components/schemas/Organisation'
             - $ref: '#/components/schemas/Agent'
@@ -1593,10 +1614,16 @@ components:
               organisation: '#/components/schemas/Organisation'
               agent: '#/components/schemas/Agent'
         declared_affiliations:
-          description: List of `organisation` that reflect the declared affiliations of a `person` contributing to a `product`.
+          description: >
+            List of Organisation identifiers reflecting the declared affiliations of a `person`
+            contributing to a `product`. Each item may be a plain identifier string or a full
+            Organisation object.
           type: array
           items:
-            $ref: '#/components/schemas/Organisation'
+            anyOf:
+              - type: string
+                description: Organisation identifier (local_identifier or external URI)
+              - $ref: '#/components/schemas/Organisation'
         rank:
           type: integer
           x-faker:
@@ -1819,9 +1846,21 @@ components:
               x-faker:
                 fake : ['{{datatype.number(5)}}']
             in:
-              $ref: '#/components/schemas/VenueLite'
+              description: >
+                Venue identifier for the manifestation. May be a plain identifier string
+                or a full Venue object.
+              anyOf:
+                - type: string
+                  description: Venue identifier (local_identifier or external URI)
+                - $ref: '#/components/schemas/VenueLite'
             hosting_data_source :
-              $ref: '#/components/schemas/DataSourceLite'
+              description: >
+                Data source identifier for the manifestation. May be a plain identifier
+                string or a full Data Source object.
+              anyOf:
+                - type: string
+                  description: Data source identifier (local_identifier or external URI)
+                - $ref: '#/components/schemas/DataSourceLite'
     ProductRelated:
       type: object
       description : A dictionary of objects representing related `product`, where the semantics of such relationships is specified as a key.
@@ -2034,8 +2073,13 @@ components:
                 required: [ "affiliation"]
                 properties:
                   affiliation:
-                    description : "`organisation` a `person` is affiliated with"
-                    $ref: "#/components/schemas/Organisation"
+                    description: >
+                      Organisation a `person` is affiliated with. May be a plain identifier
+                      string or a full Organisation object.
+                    anyOf:
+                      - type: string
+                        description: Organisation identifier (local_identifier or external URI)
+                      - $ref: "#/components/schemas/Organisation"
                   role :
                     type: string
                     default: "affiliate"
@@ -2231,10 +2275,15 @@ components:
               examples:
                 - "https://graspos.eu"
             beneficiaries:
-              description: "List of `organisation` funded by the `grant`"
+              description: >
+                List of Organisation identifiers funded by the `grant`. Each item may be a
+                plain identifier string or a full Organisation object.
               type: array
               items:
-                $ref: '#/components/schemas/Organisation'
+                anyOf:
+                  - type: string
+                    description: Organisation identifier (local_identifier or external URI)
+                  - $ref: '#/components/schemas/Organisation'
             contributions:
               type: array
               description: List of objects describing a `person` or `organisation`, its role, contribution, rank, when working on the `grant`.
@@ -2246,8 +2295,12 @@ components:
       description: 'Grant contribution. Describes a `person` or `organisation`, its role, contribution, rank, when working on a `grant`. See SKG-IF definition [Grant contribution](https://skg-if.github.io/interoperability-framework/docs/grant.html#contributions) ( entity_type:grant ).'
       properties:
         by:
-          description: The identifier of a `person` or `organisation` contributing to a `grant`.
-          oneOf:
+          description: >
+            Identifier of a `person` or `organisation` contributing to a `grant`. May be
+            a plain identifier string or a typed object (discriminated by entity_type).
+          anyOf:
+            - type: string
+              description: Agent identifier (local_identifier or external URI)
             - $ref: '#/components/schemas/PersonLite'
             - $ref: '#/components/schemas/Organisation'
           discriminator:
@@ -2256,10 +2309,16 @@ components:
               person: '#/components/schemas/PersonLite'
               organisation: '#/components/schemas/Organisation'
         declared_affiliations:
-          description: List of `organisation` that reflect the declared affiliations of a `person` contributing to a `grant`.
+          description: >
+            List of Organisation identifiers reflecting the declared affiliations of a `person`
+            contributing to a `grant`. Each item may be a plain identifier string or a full
+            Organisation object.
           type: array
           items:
-            $ref: '#/components/schemas/Organisation'
+            anyOf:
+              - type: string
+                description: Organisation identifier (local_identifier or external URI)
+              - $ref: '#/components/schemas/Organisation'
         roles:
           description: |
             The roles that a `person` or `organisation` had in a `grant`.\
@@ -2350,8 +2409,13 @@ components:
               examples:
                  - "GraspOS"
             funding_agency:
-              description : "`organisation` funding the `grant`."
-              $ref: "#/components/schemas/Organisation"
+              description: >
+                Organisation funding the `grant`. May be a plain identifier string
+                or a full Organisation object.
+              anyOf:
+                - type: string
+                  description: Organisation identifier (local_identifier or external URI)
+                - $ref: "#/components/schemas/Organisation"
             funding_stream:
               description : "funding stream of the `grant`"
               type: string

--- a/openapi/ver/current/skg-if-openapi.yaml
+++ b/openapi/ver/current/skg-if-openapi.yaml
@@ -280,6 +280,7 @@ paths:
               summary : search product which title contains 'ocean'
         - $ref : '#/components/parameters/pageQueryParam'
         - $ref : '#/components/parameters/pageSizeQueryParam'
+        - $ref : '#/components/parameters/expandQueryParam'
       responses:
         '200':
           description: |
@@ -494,6 +495,7 @@ paths:
               summary: Get all person with identifier scheme 'orcid' and id '0000-0002-1825-0097'
         - $ref : '#/components/parameters/pageQueryParam'
         - $ref : '#/components/parameters/pageSizeQueryParam'
+        - $ref : '#/components/parameters/expandQueryParam'
       responses:
         '200':
           description: Success
@@ -717,6 +719,7 @@ paths:
             pattern: '^(,?.+:.+)*$'
         - $ref : '#/components/parameters/pageQueryParam'
         - $ref : '#/components/parameters/pageSizeQueryParam'
+        - $ref : '#/components/parameters/expandQueryParam'
       responses:
         '200':
           description: Success
@@ -940,6 +943,7 @@ paths:
               summary: Get all grants with title containing `GraspOS`
         - $ref : '#/components/parameters/pageQueryParam'
         - $ref : '#/components/parameters/pageSizeQueryParam'
+        - $ref : '#/components/parameters/expandQueryParam'
       responses:
         '200':
           description: Success
@@ -1066,6 +1070,7 @@ paths:
               summary: Get all venues with name containing 'Psychoceramics'
         - $ref : '#/components/parameters/pageQueryParam'
         - $ref : '#/components/parameters/pageSizeQueryParam'
+        - $ref : '#/components/parameters/expandQueryParam'
       responses:
         '200':
           description: Success
@@ -1203,6 +1208,7 @@ paths:
               summary: Get all topics with label containing 'Solar' in the scheme 'myvocabulary'
         - $ref : '#/components/parameters/pageQueryParam'
         - $ref : '#/components/parameters/pageSizeQueryParam'
+        - $ref : '#/components/parameters/expandQueryParam'
       responses:
         '200':
           description: Success
@@ -1331,6 +1337,7 @@ paths:
               summary: Get all datasources with name containing `Oxford`
         - $ref : '#/components/parameters/pageQueryParam'
         - $ref : '#/components/parameters/pageSizeQueryParam'
+        - $ref : '#/components/parameters/expandQueryParam'
       responses:
         '200':
           description: Success
@@ -1432,6 +1439,39 @@ components:
             Search page size. limit search result size.
       schema:
         type: integer
+    expandQueryParam:
+      name: expand
+      in: query
+      description: |
+        When `true`, instruct the server to expand cross-reference properties from plain
+        `local_identifier` strings to inline entity objects wherever possible.
+        The schema for each property defines the expected representation — some properties
+        expand to Lite entities (e.g. `GrantLite` for `funding`, `VenueLite` for
+        `manifestations[].biblio.in`) while others expand to full entity objects
+        (e.g. `Organisation` for `relevant_organisations`).
+
+        Applies to: `relevant_organisations`, `funding`, `contributions[].by`,
+        `contributions[].declared_affiliations`, `manifestations[].biblio.in`,
+        `manifestations[].biblio.hosting_data_source`, `topics[].term`,
+        `affiliations[].affiliation`, `beneficiaries`, and `funding_agency`.
+
+        > **Background:** All cross-reference properties in the SKG-IF JSON-LD context
+        > (verified across all context versions, 0.1.0 onwards) are defined with
+        > `"@type": "@vocab"` — meaning they are IRI references (local_identifiers) at the
+        > ontology level. The inline Lite/entity object forms are an API-level convenience
+        > supported by the OpenAPI spec on top of the data model. Without `expand=true`
+        > (default), responses reflect whatever representation the data store holds.
+        > With `expand=true`, the server resolves string identifiers to entity objects
+        > where possible.
+
+        If a referenced entity cannot be resolved, the server returns the original
+        identifier string suffixed by ` UNEXPANDABLE` to signal the failure.
+
+        > **Note for implementers:** This parameter is optional. Servers that do not support
+        > expansion may ignore it or return HTTP 422.
+      schema:
+        type: boolean
+        default: false
   schemas:
     Product:
       type: object

--- a/openapi/ver/current/skg-if-openapi.yaml
+++ b/openapi/ver/current/skg-if-openapi.yaml
@@ -1380,12 +1380,35 @@ components:
       name: short_local_identifier
       in: path
       description: |
-        entity id. URL suffix used in OpenAPI get by id operations. \
-        `https://[your-server-root-skg-if-url]/[products|persons|organisations|datasources|venues|topics]/{short_local_identifier}` \
-        example `http://example.com/skg-if/api/products/c66c6-38be-4d5f-85db-d44c9`
+        The `local_identifier` of the entity to retrieve. Follows the SKG-IF convention —
+        always interpreted as a URL, in one of three forms:
+
+        1. **Full URL** — any URL, used as-is as the entity identifier (e.g. a server API URL,
+           a DOI, a ROR URL, or an SKG-IF sandbox URL)
+        2. **Plain string** — resolved by prepending the `@base` from the JSON-LD preamble;
+           the framework prescribes `https://w3id.org/skg-if/sandbox/<provider-acronym>/` as the
+           `@base` for entities that have no independently dereferenceable identifier of their own,
+           producing a *sandbox URL* — but any `@base` value is valid
+        3. **On-the-fly** — plain string using the template `otf___<session-id>___<identifier-string>`,
+           also resolved via `@base`, for identifiers created on-the-fly during document generation
+
+        **Note:** identifiers containing `/` must have slashes percent-encoded as `%2F` in the URL.
       required: true
       schema:
         type: string
+      examples:
+        full_url_server:
+          summary: Full URL — server API URL as local_identifier
+          value: "http://example.com/skg-if/api/products/prd-c66c6-38be-4d5f-85db-d44c9f869333"
+        full_url_sandbox:
+          summary: Full URL — SKG-IF sandbox identifier (pre-expanded form of a plain string)
+          value: "https://w3id.org/skg-if/sandbox/clarin-vlo/11234/1-4816"
+        short_string:
+          summary: Plain string resolved via @base (slashes percent-encoded in URL as %2F)
+          value: "11234/1-4816"
+        on_the_fly:
+          summary: On-the-fly identifier resolved via @base
+          value: "otf___1730027051396___person-1"
 #    filterQueryParam: # filterQueryParam duplicated in each search endpoint ( only way to add distinct examples for each endpoint )
 #      name: filter
 #      in: query

--- a/openapi/ver/current/skg-if-openapi.yaml
+++ b/openapi/ver/current/skg-if-openapi.yaml
@@ -74,6 +74,7 @@ paths:
       operationId: getProductById
       parameters:
         - $ref : '#/components/parameters/shortLocalIdPathParam'
+        - $ref : '#/components/parameters/embeddingQueryParam'
       responses:
         '200':
           description: |
@@ -280,7 +281,7 @@ paths:
               summary : search product which title contains 'ocean'
         - $ref : '#/components/parameters/pageQueryParam'
         - $ref : '#/components/parameters/pageSizeQueryParam'
-        - $ref : '#/components/parameters/expandQueryParam'
+        - $ref : '#/components/parameters/embeddingQueryParam'
       responses:
         '200':
           description: |
@@ -383,6 +384,7 @@ paths:
       operationId: getPersonById
       parameters:
         - $ref : '#/components/parameters/shortLocalIdPathParam'
+        - $ref : '#/components/parameters/embeddingQueryParam'
       responses:
         '200':
           description: Success
@@ -495,7 +497,7 @@ paths:
               summary: Get all person with identifier scheme 'orcid' and id '0000-0002-1825-0097'
         - $ref : '#/components/parameters/pageQueryParam'
         - $ref : '#/components/parameters/pageSizeQueryParam'
-        - $ref : '#/components/parameters/expandQueryParam'
+        - $ref : '#/components/parameters/embeddingQueryParam'
       responses:
         '200':
           description: Success
@@ -573,6 +575,7 @@ paths:
       operationId: getOrganisationById
       parameters:
         - $ref : '#/components/parameters/shortLocalIdPathParam'
+        - $ref : '#/components/parameters/embeddingQueryParam'
       responses:
         '200':
           description: Success
@@ -719,7 +722,7 @@ paths:
             pattern: '^(,?.+:.+)*$'
         - $ref : '#/components/parameters/pageQueryParam'
         - $ref : '#/components/parameters/pageSizeQueryParam'
-        - $ref : '#/components/parameters/expandQueryParam'
+        - $ref : '#/components/parameters/embeddingQueryParam'
       responses:
         '200':
           description: Success
@@ -757,6 +760,7 @@ paths:
       operationId: getGrantById
       parameters:
         - $ref : '#/components/parameters/shortLocalIdPathParam'
+        - $ref : '#/components/parameters/embeddingQueryParam'
       responses:
         '200':
           description: Success
@@ -943,7 +947,7 @@ paths:
               summary: Get all grants with title containing `GraspOS`
         - $ref : '#/components/parameters/pageQueryParam'
         - $ref : '#/components/parameters/pageSizeQueryParam'
-        - $ref : '#/components/parameters/expandQueryParam'
+        - $ref : '#/components/parameters/embeddingQueryParam'
       responses:
         '200':
           description: Success
@@ -981,6 +985,7 @@ paths:
       operationId: getVenueById
       parameters:
         - $ref : '#/components/parameters/shortLocalIdPathParam'
+        - $ref : '#/components/parameters/embeddingQueryParam'
       responses:
         '200':
           description: Success
@@ -1070,7 +1075,7 @@ paths:
               summary: Get all venues with name containing 'Psychoceramics'
         - $ref : '#/components/parameters/pageQueryParam'
         - $ref : '#/components/parameters/pageSizeQueryParam'
-        - $ref : '#/components/parameters/expandQueryParam'
+        - $ref : '#/components/parameters/embeddingQueryParam'
       responses:
         '200':
           description: Success
@@ -1108,6 +1113,7 @@ paths:
       operationId: getTopicById
       parameters:
         - $ref : '#/components/parameters/shortLocalIdPathParam'
+        - $ref : '#/components/parameters/embeddingQueryParam'
       responses:
         '200':
           description: Success
@@ -1208,7 +1214,7 @@ paths:
               summary: Get all topics with label containing 'Solar' in the scheme 'myvocabulary'
         - $ref : '#/components/parameters/pageQueryParam'
         - $ref : '#/components/parameters/pageSizeQueryParam'
-        - $ref : '#/components/parameters/expandQueryParam'
+        - $ref : '#/components/parameters/embeddingQueryParam'
       responses:
         '200':
           description: Success
@@ -1246,6 +1252,7 @@ paths:
       operationId: getDataSourceById
       parameters:
         - $ref : '#/components/parameters/shortLocalIdPathParam'
+        - $ref : '#/components/parameters/embeddingQueryParam'
       responses:
         '200':
           description: Success
@@ -1337,7 +1344,7 @@ paths:
               summary: Get all datasources with name containing `Oxford`
         - $ref : '#/components/parameters/pageQueryParam'
         - $ref : '#/components/parameters/pageSizeQueryParam'
-        - $ref : '#/components/parameters/expandQueryParam'
+        - $ref : '#/components/parameters/embeddingQueryParam'
       responses:
         '200':
           description: Success
@@ -1439,8 +1446,8 @@ components:
             Search page size. limit search result size.
       schema:
         type: integer
-    expandQueryParam:
-      name: expand
+    embeddingQueryParam:
+      name: embedding
       in: query
       description: |
         When `true`, instruct the server to expand cross-reference properties from plain
@@ -1459,9 +1466,9 @@ components:
         > (verified across all context versions, 0.1.0 onwards) are defined with
         > `"@type": "@vocab"` — meaning they are IRI references (local_identifiers) at the
         > ontology level. The inline Lite/entity object forms are an API-level convenience
-        > supported by the OpenAPI spec on top of the data model. Without `expand=true`
+        > supported by the OpenAPI spec on top of the data model. Without `embedding=true`
         > (default), responses reflect whatever representation the data store holds.
-        > With `expand=true`, the server resolves string identifiers to entity objects
+        > With `embedding=true`, the server resolves string identifiers to entity objects
         > where possible.
 
         If a referenced entity cannot be resolved, the server returns the original

--- a/openapi/ver/current/skg-if-openapi.yaml
+++ b/openapi/ver/current/skg-if-openapi.yaml
@@ -2550,6 +2550,21 @@ components:
           description: search result page type
           enum:
             - search_result_page
+        page:
+          description: current page number
+          type: integer
+          examples:
+            - 1
+        page_size:
+          description: maximum number of items per page
+          type: integer
+          examples:
+            - 10
+        items_count:
+          description: number of items returned on this page
+          type: integer
+          examples:
+            - 10
         prev_page:
           description: Previous page reference
           type: object


### PR DESCRIPTION
Several cross-reference properties (references to other entities) are documented as accepting plain identifier strings (e.g.
  `"org_1"`, `"ven1"`) but the schema defined them as `$ref` object types only, causing validators to reject data the docs
  explicitly show as valid.

  Changes from bare `$ref` / `oneOf` to `anyOf: [string | $ref]` for:
  - **Product**: `topics[].term`, `relevant_organisations[]`, `funding[]`, `contributions[].declared_affiliations[]`,
  `contributions[].by`, `manifestations[].biblio.in`, `manifestations[].biblio.hosting_data_source`
  - **Person/Agent**: `affiliations[].affiliation`
  - **Grant**: `beneficiaries[]`, `contributions[].declared_affiliations[]`, `contributions[].by`, `funding_agency`

  API responses may still return expanded objects.

additional commits made to be in sync with latest discussion on local_identifier format and use and rules for the expand/embedded parameter